### PR TITLE
Corrected “Runpath Search Paths” setting for XCode

### DIFF
--- a/Syphon-Transmit/Mac/Syphon Transmit.xcodeproj/project.pbxproj
+++ b/Syphon-Transmit/Mac/Syphon Transmit.xcodeproj/project.pbxproj
@@ -284,7 +284,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Library/Bundles";
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks/$(EXECUTABLE_PATH)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Adobe\"";
 				MARKETING_VERSION = "1.0 Beta 1";
 				ONLY_ACTIVE_ARCH = YES;
@@ -312,7 +312,7 @@
 				);
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Library/Bundles";
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks/$(EXECUTABLE_PATH)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Adobe\"";
 				MARKETING_VERSION = "1.0 Beta 1";
 				ONLY_ACTIVE_ARCH = NO;


### PR DESCRIPTION
Prior to this commit, the code would build into the .bundle file, but After Effects 2026 and Premiere Pro 2026 would not load it on startup.  Changing the “Runpath Search Paths” settings fixed this issue.